### PR TITLE
reset io add to execute_processing for && || case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ UTIL_SRCS = $(addprefix $(SRCS_DIR)/$(UTILS_DIR)/, \
 			ft_error.c	\
 			exit_status.c \
 			check_valid_variable.c	\
+			ft_is_whitespace.c	\
 			utils.c	\
 )
 

--- a/include/execute.h
+++ b/include/execute.h
@@ -6,7 +6,7 @@
 /*   By: jim <jim@student.42seoul.kr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/18 16:33:03 by jim               #+#    #+#             */
-/*   Updated: 2022/08/13 20:58:33 by jim              ###   ########seoul.kr  */
+/*   Updated: 2022/08/14 22:30:33 by jim              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,8 +18,9 @@
 # include "env_list.h"
 
 int		execute_processing(t_env_list *env_list, t_list *parse_list, \
-							int is_child);
-int		pipeline_processing(t_env_list *env_list, t_list *pipeline_list);
+							int is_child, int io_backup[2]);
+int		pipeline_processing(t_env_list *env_list, t_list *pipeline_list, \
+							int io_bacup[2]);
 void	execute_cmd(char **envp, char **cmd);
 int		simple_cmd(t_env_list *env_list, t_simple *scmd_list, int is_child);
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,7 +6,7 @@
 /*   By: jim <jim@student.42seoul.kr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/25 14:45:28 by jim               #+#    #+#             */
-/*   Updated: 2022/08/12 13:33:14 by jim              ###   ########.fr       */
+/*   Updated: 2022/08/14 22:27:47 by jim              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,5 +47,7 @@ int		check_start_of_variable(char ch);
 int		check_mid_of_variable(char ch);
 void	safe_free(char **char_pptr);
 void	safe_free_cast(void **char_pptr, int size);
+
+int		reset_in_out_fd(int io_backup[2]);
 
 #endif

--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -6,7 +6,7 @@
 /*   By: jim <jim@student.42seoul.kr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/18 15:58:05 by jim               #+#    #+#             */
-/*   Updated: 2022/08/14 18:06:28 by jim              ###   ########.fr       */
+/*   Updated: 2022/08/14 22:40:10 by jim              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -108,30 +108,32 @@ static int	check_execute_operator_skip(t_list *parse_list)
 		return (0);
 }
 
-int	execute_processing(t_env_list *env_list, t_list *parse_list, int is_child)
+int	execute_processing(t_env_list *env_list, t_list *parse_list, \
+						int is_child, int io_backup[2])
 {
 	t_simple	*scmd_list;
 
-	scmd_list = get_simple(parse_list);
 	if (env_list == NULL || parse_list == NULL)
 		return (1);
+	scmd_list = get_simple(parse_list);
 	if (get_command_type(parse_list) == SIMPLE_NORMAL)
 		update_exit_status(simple_cmd(env_list, scmd_list, is_child));
 	else if (get_command_type(parse_list) == COMPOUND_PIPELINE)
 		update_exit_status(pipeline_processing(env_list, \
-											get_compound(parse_list)->list));
+								get_compound(parse_list)->list, io_backup));
 	else if (get_command_type(parse_list) == COMPOUND_SUBSHELL)
 		update_exit_status(execute_processing(env_list, \
-											get_compound(parse_list)->list, \
-											is_child));
+								get_compound(parse_list)->list, \
+											is_child, io_backup));
 	if (parse_list->next)
 	{
+		reset_in_out_fd(io_backup);
 		parse_list = parse_list->next;
 		while (parse_list && check_execute_operator_skip(parse_list))
 			parse_list = parse_list->next->next;
 		if (parse_list != NULL)
 			update_exit_status(execute_processing(env_list, parse_list, \
-												is_child));
+												is_child, io_backup));
 	}
 	return (*(get_exit_status()));
 }

--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -6,7 +6,7 @@
 /*   By: jim <jim@student.42seoul.kr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/18 15:58:05 by jim               #+#    #+#             */
-/*   Updated: 2022/08/14 22:40:10 by jim              ###   ########.fr       */
+/*   Updated: 2022/08/14 22:56:59 by jim              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -111,13 +111,11 @@ static int	check_execute_operator_skip(t_list *parse_list)
 int	execute_processing(t_env_list *env_list, t_list *parse_list, \
 						int is_child, int io_backup[2])
 {
-	t_simple	*scmd_list;
-
 	if (env_list == NULL || parse_list == NULL)
 		return (1);
-	scmd_list = get_simple(parse_list);
 	if (get_command_type(parse_list) == SIMPLE_NORMAL)
-		update_exit_status(simple_cmd(env_list, scmd_list, is_child));
+		update_exit_status(simple_cmd(env_list, get_simple(parse_list), \
+							is_child));
 	else if (get_command_type(parse_list) == COMPOUND_PIPELINE)
 		update_exit_status(pipeline_processing(env_list, \
 								get_compound(parse_list)->list, io_backup));
@@ -127,7 +125,8 @@ int	execute_processing(t_env_list *env_list, t_list *parse_list, \
 											is_child, io_backup));
 	if (parse_list->next)
 	{
-		reset_in_out_fd(io_backup);
+		if (reset_in_out_fd(io_backup) < 0)
+			return (1);
 		parse_list = parse_list->next;
 		while (parse_list && check_execute_operator_skip(parse_list))
 			parse_list = parse_list->next->next;

--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -6,7 +6,7 @@
 /*   By: jim <jim@student.42seoul.kr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/18 15:58:05 by jim               #+#    #+#             */
-/*   Updated: 2022/08/14 15:48:12 by jim              ###   ########.fr       */
+/*   Updated: 2022/08/14 18:06:28 by jim              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -97,12 +97,12 @@ int	simple_cmd(t_env_list *env_list, t_simple *scmd_list, int is_child)
 
 static int	check_execute_operator_skip(t_list *parse_list)
 {
-	int	operator;
+	int	_operator;
 
-	operator = get_command_type(parse_list);
-	if (operator & SIMPLE_AND && *get_exit_status() != 0)
+	_operator = get_command_type(parse_list);
+	if (_operator & SIMPLE_AND && *get_exit_status() != 0)
 		return (1);
-	else if (operator & SIMPLE_OR && *get_exit_status() == 0)
+	else if (_operator & SIMPLE_OR && *get_exit_status() == 0)
 		return (1);
 	else
 		return (0);

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -6,13 +6,14 @@
 /*   By: jim <jim@student.42seoul.kr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/24 22:49:58 by jim               #+#    #+#             */
-/*   Updated: 2022/08/14 17:51:10 by gyepark          ###   ########.kr       */
+/*   Updated: 2022/08/14 22:27:55 by jim              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <readline/readline.h>
 #include <readline/history.h>
+#include <stdlib.h>
 #include <stddef.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -29,7 +30,6 @@
 #include "constants.h"
 #include "lexer_util.h"
 #include "destruct.h"
-#include <stdlib.h>
 
 static int	preprocess(char *input, t_list *parsed_header)
 {
@@ -42,14 +42,6 @@ static int	preprocess(char *input, t_list *parsed_header)
 		free(input);
 		return (1);
 	}
-	return (0);
-}
-
-static int	reset_in_out_fd(int io_backup[2])
-{
-	if (dup2(io_backup[0], STDIN_FILENO) < 0
-		|| dup2(io_backup[1], STDOUT_FILENO) < 0)
-		return (-1);
 	return (0);
 }
 
@@ -96,7 +88,7 @@ int	main(int argc, char **argv, char **envp)
 			continue ;
 		if (preprocess(input, &parsed_header))
 			continue ;
-		execute_processing(env_list, parsed_header.next, FALSE);
+		execute_processing(env_list, parsed_header.next, FALSE, io_backup);
 		add_history(input);
 		if (reset_in_out_fd(io_backup) < 0)
 			return (wrapper_free_input_and_parse(&input, \

--- a/srcs/utils/utils.c
+++ b/srcs/utils/utils.c
@@ -6,12 +6,13 @@
 /*   By: jim <jim@student.42seoul.kr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/28 14:10:59 by jim               #+#    #+#             */
-/*   Updated: 2022/08/12 17:12:16 by jim              ###   ########.fr       */
+/*   Updated: 2022/08/14 22:28:41 by jim              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "utils.h"
+#include <unistd.h>
 #include <stdlib.h>
+#include "utils.h"
 
 /*
 	gnu bash
@@ -78,9 +79,10 @@ size_t	max_nonnegative(char const *s1, char const *s2)
 	return (s2_size);
 }
 
-int	is_whitespace(char const ch)
+int	reset_in_out_fd(int io_backup[2])
 {
-	if (ch == ' ' || ch == '\t')
-		return (1);
+	if (dup2(io_backup[0], STDIN_FILENO) < 0
+		|| dup2(io_backup[1], STDOUT_FILENO) < 0)
+		return (-1);
 	return (0);
 }


### PR DESCRIPTION
ls > outfile && echo aa
ls > outfile 하면 STDOUT이 outfile fd를 가리키기 때문에
echo aa 결과가 STDOUT가 가리키게된 outfile의 fd를 가리키기 때문에 결과가 달랐더라고요
[10:37](https://42born2code.slack.com/archives/D02LNTCGHMF/p1660484263884669)
그래서 맨처음에 main에서 담아둔 STDIN,STDOUT fd를 execute함수에서 다시 원상복구